### PR TITLE
Merge pull request from fsnfsn/17045

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,7 +631,9 @@ By default youtube-dl tries to download the best available quality, i.e. if you 
 
 But sometimes you may want to download in a different format, for example when you are on a slow or intermittent connection. The key mechanism for achieving this is so-called *format selection* based on which you can explicitly specify desired format, select formats based on some criterion or criteria, setup precedence and much more.
 
-The general syntax for format selection is `--format FORMAT` or shorter `-f FORMAT` where `FORMAT` is a *selector expression*, i.e. an expression that describes format or formats you would like to download.
+The general syntax for format selection is `--format FORMAT` or shorter `-f FORMAT` where `FORMAT` is a *selector expression*, i.e. an expression that describes format or formats you would like to download.  
+
+To avoid the case where the audio and video are incompatible, specify both the format of the audio and video streams explicitly.  For example specifying `-f mp4` will default to `-f mp4,best`, but the best audio youtube can provide cannot be contained in an `MP4` file, so youtube-dl will try to merge them into an `mkv` instead of the requested `mp4` format.  To avoid this, specify `-f mp4,mp4`, so the audio and video are compatible.
 
 **tl;dr:** [navigate me to examples](#format-selection-examples).
 


### PR DESCRIPTION
I was having strange behaviour where downloading from youtube, sometimes could not merge the audio and video streams without making it matroska, even though I asked for mp4.  I found I can work around this by explicitly stating both desired audio and video format, since apparently passing `-f mp4` only specifies the desired video format, and does not try to transcode audio to this format.

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [ ] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [ ] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [ ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.
